### PR TITLE
Adding adminCode field to cope with a model which has multiple admin

### DIFF
--- a/Admin/AdminExtension.php
+++ b/Admin/AdminExtension.php
@@ -49,7 +49,9 @@ class AdminExtension extends BaseAdminExtension
      */
     protected function getTarget(AdminInterface $admin, $object)
     {
-        return $this->actionManager->findOrCreateComponent($admin->getClass(), $admin->id($object));
+        $component = $this->actionManager->findOrCreateComponent($admin->getClass(), $admin->id($object));
+    	$component->setAdminCode($admin->getCode());
+    	return $component;
     }
 
     /**

--- a/Entity/Component.php
+++ b/Entity/Component.php
@@ -21,4 +21,32 @@ use Spy\TimelineBundle\Entity\Component as BaseComponent;
  */
 class Component extends BaseComponent
 {
+	/**
+	 * @var string
+	 */
+	protected $adminCode;
+	
+	
+	/**
+	 * Set adminCode
+	 *
+	 * @param string $adminCode
+	 * @return Component
+	 */
+	public function setAdminCode($adminCode)
+	{
+		$this->adminCode = $adminCode;
+	
+		return $this;
+	}
+	
+	/**
+	 * Get adminCode
+	 *
+	 * @return string
+	 */
+	public function getAdminCode()
+	{
+		return $this->adminCode;
+	}
 }

--- a/Resources/config/doctrine/Component.orm.xml.skeleton
+++ b/Resources/config/doctrine/Component.orm.xml.skeleton
@@ -16,6 +16,6 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
-
+		<field name="adminCode" column="adminCode" type="string" length="255" nullable="true" />
     </entity>
 </doctrine-mapping>

--- a/Twig/Extension/SonataTimelineExtension.php
+++ b/Twig/Extension/SonataTimelineExtension.php
@@ -58,7 +58,12 @@ class SonataTimelineExtension extends \Twig_Extension
             return $component->getHash();
         }
 
-        $admin = $this->pool->getAdminByClass($component->getModel());
+    if (is_null($component->getAdminCode())) {
+        	$admin = $this->pool->getAdminByClass($component->getModel());
+        }
+        else {
+        	$admin = $this->pool->getAdminByAdminCode($component->getAdminCode());
+        }
 
         if (!$admin) {
             return $component->getHash();


### PR DESCRIPTION
@rande :  
I had a bug while an entity has multiple admin classes :  
"An exception has been thrown during the rendering of a template ("Unable to found a valid admin for the class...."

So I added a new field named "adminCode" to the "Component" entity and I worked with.

I don't know if it's good practical but it solve my problem.