### PR TITLE
Check routes before generating component url

### DIFF
--- a/Tests/Twig/Extension/SonataTimelineExtensionTest.php
+++ b/Tests/Twig/Extension/SonataTimelineExtensionTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of sonata-project.
+ *
+ * (c) 2010 Thomas Rabaix
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\TimelineBundle\Tests\Twig\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\TimelineBundle\Twig\Extension\SonataTimelineExtension;
+use Spy\TimelineBundle\Document\Action;
+use Spy\TimelineBundle\Document\Component;
+
+class SonataTimelineExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SonataTimelineExtension
+     */
+    private $twigExtension;
+
+    /**
+     * @var AdminInterface
+     */
+    private $pool;
+
+    /**
+     * @var Pool
+     */
+    private $admin;
+
+    public function setUp()
+    {
+        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface', array('hasRoute', 'isGranted', 'generateObjectUrl', 'generateUrl', 'toString'));
+
+        $this->pool = $this->getMock('Sonata\AdminBundle\Admin\Pool', array('getAdminByClass'));
+        $this->pool->expects($this->any())
+            ->method('getAdminByClass')
+            ->with($this->equalTo('Acme\DemoBundle\Model\Demo'))
+            ->will($this->returnValue($this->admin));
+
+        $this->twigExtension = new SonataTimelineExtension($this->pool);
+    }
+
+    public function testGenerateLink()
+    {
+        $component = new Component();
+        $component->setModel('Acme\DemoBundle\Model\Demo');
+        $component->setIdentifier(array('2'));
+
+        $action = new Action();
+
+        $this->admin->expects($this->once())
+            ->method('hasRoute')
+            ->with($this->equalTo('edit'))
+            ->will($this->returnValue(true));
+        $this->admin->expects($this->once())
+            ->method('isGranted')
+            ->with($this->equalTo('EDIT'))
+            ->will($this->returnValue(true));
+
+        $this->admin->expects($this->once())
+            ->method('generateObjectUrl')
+            ->with($this->equalTo('edit'), $this->anything())
+            ->will($this->returnValue('acme/demo/2/edit'));
+
+        $this->admin->expects($this->once())
+            ->method('toString')
+            ->with($this->anything())
+            ->will($this->returnValue('Text'));
+
+        $this->assertEquals('<a href="acme/demo/2/edit">Text</a>', $this->twigExtension->generateLink($component, $action));
+    }
+
+    public function testGenerateLinkDisabledEdit()
+    {
+        $component = new Component();
+        $component->setModel('Acme\DemoBundle\Model\Demo');
+        $component->setIdentifier(array('2'));
+
+        $action = new Action();
+
+        $this->admin->expects($this->at(0))
+            ->method('hasRoute')
+            ->with($this->equalTo('edit'))
+            ->will($this->returnValue(false));
+        $this->admin->expects($this->at(1))
+            ->method('hasRoute')
+            ->with($this->equalTo('show'))
+            ->will($this->returnValue(true));
+        $this->admin->expects($this->at(2))
+            ->method('isGranted')
+            ->with($this->equalTo('SHOW'))
+            ->will($this->returnValue(true));
+
+        $this->admin->expects($this->once())
+            ->method('generateObjectUrl')
+            ->with($this->equalTo('show'), $this->anything())
+            ->will($this->returnValue('acme/demo/2/show'));
+
+        $this->admin->expects($this->once())
+            ->method('toString')
+            ->with($this->anything())
+            ->will($this->returnValue('Text'));
+
+        $this->assertEquals('<a href="acme/demo/2/show">Text</a>', $this->twigExtension->generateLink($component, $action));
+    }
+
+    public function testGenerateLinkNoEditPermission()
+    {
+        $component = new Component();
+        $component->setModel('Acme\DemoBundle\Model\Demo');
+        $component->setIdentifier(array('2'));
+
+        $action = new Action();
+
+        $this->admin->expects($this->at(0))
+            ->method('hasRoute')
+            ->with($this->equalTo('edit'))
+            ->will($this->returnValue(true));
+        $this->admin->expects($this->at(1))
+            ->method('isGranted')
+            ->with($this->equalTo('EDIT'))
+            ->will($this->returnValue(false));
+        $this->admin->expects($this->at(2))
+            ->method('hasRoute')
+            ->with($this->equalTo('show'))
+            ->will($this->returnValue(true));
+        $this->admin->expects($this->at(3))
+            ->method('isGranted')
+            ->with($this->equalTo('SHOW'))
+            ->will($this->returnValue(true));
+
+        $this->admin->expects($this->once())
+            ->method('generateObjectUrl')
+            ->with($this->equalTo('show'), $this->anything())
+            ->will($this->returnValue('acme/demo/2/show'));
+
+        $this->admin->expects($this->once())
+            ->method('toString')
+            ->with($this->anything())
+            ->will($this->returnValue('Text'));
+
+        $this->assertEquals('<a href="acme/demo/2/show">Text</a>', $this->twigExtension->generateLink($component, $action));
+    }
+
+    public function testGenerateLinkDisabledEditAndShow()
+    {
+        $component = new Component();
+        $component->setModel('Acme\DemoBundle\Model\Demo');
+        $component->setIdentifier('2');
+
+        $action = new Action();
+
+        $this->admin->expects($this->at(0))
+            ->method('hasRoute')
+            ->with($this->equalTo('edit'))
+            ->will($this->returnValue(false));
+        $this->admin->expects($this->at(1))
+            ->method('hasRoute')
+            ->with($this->equalTo('show'))
+            ->will($this->returnValue(false));
+
+        $this->admin->expects($this->once())
+            ->method('toString')
+            ->with($this->anything())
+            ->will($this->returnValue('Text'));
+
+        $this->assertEquals('Text', $this->twigExtension->generateLink($component, $action));
+    }
+}

--- a/Twig/Extension/SonataTimelineExtension.php
+++ b/Twig/Extension/SonataTimelineExtension.php
@@ -65,10 +65,17 @@ class SonataTimelineExtension extends \Twig_Extension
             return $component->getHash();
         }
 
-        return sprintf('<a href="%s">%s</a>',
-            $admin->generateObjectUrl('edit', $component->getData()),
-            $admin->toString($component->getData())
-        );
+        foreach (array('edit', 'show') as $mode) {
+            if ($admin->hasRoute($mode) && $admin->isGranted(strtoupper($mode))) {
+                return sprintf(
+                    '<a href="%s">%s</a>',
+                    $admin->generateObjectUrl($mode, $component->getData()),
+                    $admin->toString($component->getData())
+                );
+            }
+        }
+
+        return $admin->toString($component->getData());
     }
 
     /**


### PR DESCRIPTION
If you disable the show or edit route in an admin, the timeline would throw an exception.