### PR TITLE
Detect user class in spread

### DIFF
--- a/Resources/config/timeline.xml
+++ b/Resources/config/timeline.xml
@@ -16,7 +16,6 @@
             <tag name="spy_timeline.spread"/>
 
             <argument type="service" id="doctrine" />
-            <argument>%sonata.user.admin.user.entity%</argument>
         </service>
 
         <service id="sonata.timeline.block.timeline" class="Sonata\TimelineBundle\Block\TimelineBlock">

--- a/Spread/AdminSpread.php
+++ b/Spread/AdminSpread.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\TimelineBundle\Spread;
 
-use FOS\UserBundle\Model\UserManagerInterface;
 use Spy\Timeline\Model\ActionInterface;
 use Spy\Timeline\Spread\Entry\EntryCollection;
 use Spy\Timeline\Spread\Entry\EntryUnaware;
@@ -32,15 +31,12 @@ class AdminSpread implements SpreadInterface
 
     protected $registry;
 
-    protected $userClass;
-
     /**
-     * @param UserManagerInterface $userManager
+     * @param RegistryInterface $registry
      */
-    public function __construct(RegistryInterface $registry, $userManager)
+    public function __construct(RegistryInterface $registry)
     {
         $this->registry = $registry;
-        $this->userClass = $userManager;
     }
 
     /**
@@ -59,7 +55,7 @@ class AdminSpread implements SpreadInterface
         $users = $this->getUsers();
 
         foreach ($users as $user) {
-            $collection->add(new EntryUnaware($this->userClass, $user[0]->getId()), 'SONATA_ADMIN');
+            $collection->add(new EntryUnaware(get_class($user[0]), $user[0]->getId()), 'SONATA_ADMIN');
         }
     }
 


### PR DESCRIPTION
When using many different user entities, the timeline block would not show any entries for an extending user.

There is for example a "Acme\User\Entity\FooUser" entity which extends the base user entity "Acme\User\Entity\User". The AdminSpread would only store the "Acme\User\Entity\User" class, but the TimelineBlock would list the "Acme\User\Entity\FooUser".