### PR TITLE
[WIP] streamline the whole documentation

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,8 +1,8 @@
 Timeline Bundle
 ===============
 
-The ``SonataTimelineBundle`` integrates the ``SpyTimelineBundle`` into Sonata. Timeline allows to create an action wall
-for a user or a group of user. The current implementation integrate the basic features of the ``SpyTimelineBundle``:
+The ``SonataTimelineBundle`` integrates the ``SpyTimelineBundle`` into ``SonataAdmin``. Timeline allows to create an action wall
+for a user or a group of users. The current implementation integrate the basic features of the ``SpyTimelineBundle``:
 
  - doctrine's models with ``SonataEasyExtends``
  - a TimelineBlock for admin action only
@@ -17,7 +17,6 @@ for a user or a group of user. The current implementation integrate the basic fe
     This is a work in progress, change may occurs in order to tweak performance issues, configuration options, or the
     rendering workflow.
 
-
 Reference Guide
 ---------------
 
@@ -26,3 +25,4 @@ Reference Guide
    :numbered:
 
    reference/installation
+   reference/configuration

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -1,0 +1,39 @@
+.. index::
+    single: Configuration
+
+Configuration
+=============
+
+Full Configuration Options
+--------------------------
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # Default configuration for extension with alias: "sonata_timeline"
+        sonata_timeline:
+            manager_type:         orm
+            class:
+                component:            '%spy_timeline.class.component%'
+                actionComponent:      ~
+                action_component:     '%spy_timeline.class.action_component%'
+                action:               '%spy_timeline.class.action%'
+                timeline:             '%spy_timeline.class.timeline%'
+
+Customize the Timeline Block
+----------------------------
+
+You can customize the ``title`` (default: ``Latest Actions``) of the block by using these config options:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+
+        sonata_admin:
+            dashboard:
+                blocks:
+                    # ...
+                    - { position: center, type: sonata.timeline.block.timeline, settings: { context: SONATA_ADMIN, max_per_page: 25, title: "My Timeline Block" }}

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -1,124 +1,154 @@
+.. index::
+    single: Installation
+    single: Configuration
+
 Installation
 ============
 
-* Add SonataTimelineBundle to your vendor/bundles dir via composer
+The easiest way to install ``SonataTimelineBundle`` is to require it with Composer:
 
-.. code-block:: json
+.. code-block:: bash
 
-    //composer.json
-    "require": {
-    //...
-        "sonata-project/timeline-bundle": "~2.2@dev",
-    //...
-    }
+    $ php composer.phar require sonata-project/timeline-bundle
 
+Alternatively, you could add a dependency into your ``composer.json`` file directly.
 
-* Add SonataTimelineBundle and SpyTimelineBundle to your AppKernel:
+.. note::
+
+    This will install the SpyTimelineBundle_, too.
+
+Now, enable the bundle in the kernel:
 
 .. code-block:: php
 
     <?php
-
     // app/AppKernel.php
+
     public function registerBundles()
     {
         return array(
             // ...
-            new Spy\TimelineBundle\SpyTimelineBundle(),
             new Sonata\CoreBundle\SonataCoreBundle(),
+            // ...
             new Sonata\TimelineBundle\SonataTimelineBundle(),
+            new Spy\TimelineBundle\SpyTimelineBundle(),
             // ...
         );
     }
 
-* Create a configuration file : ``sonata_timeline.yml``:
+Configuration
+-------------
 
-.. code-block:: yaml
+To use the ``BlockBundle``, add the following lines to your application configuration file:
 
-    spy_timeline:
-        drivers:
-            orm:
-                object_manager: doctrine.orm.entity_manager
-                classes:
-                    query_builder: ~ # Spy\TimelineBundle\Driver\ORM\QueryBuilder\QueryBuilder
-                    timeline:         Application\Sonata\TimelineBundle\Entity\Timeline
-                    action:           Application\Sonata\TimelineBundle\Entity\Action
-                    component:        Application\Sonata\TimelineBundle\Entity\Component
-                    action_component: Application\Sonata\TimelineBundle\Entity\ActionComponent
+.. configuration-block::
 
-        filters:
-            data_hydrator:
-                priority:             20
-                service:              spy_timeline.filter.data_hydrator
-                filter_unresolved:    false
-                locators:
-                    - spy_timeline.filter.data_hydrator.locator.doctrine_orm
+    .. code-block:: yaml
 
-    sonata_timeline:
-        manager_type:         orm
-        class:
-            timeline:         %spy_timeline.class.timeline%
-            action:           %spy_timeline.class.action%
-            component:        %spy_timeline.class.component%
-            action_component: %spy_timeline.class.action_component%
+        # app/config/config.yml
 
+        spy_timeline:
+            drivers:
+                orm:
+                    object_manager: doctrine.orm.entity_manager
+                    classes:
+                        query_builder: ~ # Spy\TimelineBundle\Driver\ORM\QueryBuilder\QueryBuilder
+                        timeline:         Application\Sonata\TimelineBundle\Entity\Timeline
+                        action:           Application\Sonata\TimelineBundle\Entity\Action
+                        component:        Application\Sonata\TimelineBundle\Entity\Component
+                        action_component: Application\Sonata\TimelineBundle\Entity\ActionComponent
 
-* import the ``sonata_timeline.yml`` file in the ``config.yml`` file:
+            filters:
+                data_hydrator:
+                    priority:             20
+                    service:              spy_timeline.filter.data_hydrator
+                    filter_unresolved:    false
+                    locators:
+                        - spy_timeline.filter.data_hydrator.locator.doctrine_orm
 
-.. code-block:: yaml
+    .. code-block:: yaml
 
-    imports:
-        #...
-        - { resource: sonata_timeline.yml }
+        # app/config/config.yml
 
+        sonata_timeline:
+            manager_type:         orm
+            class:
+                timeline:         %spy_timeline.class.timeline%
+                action:           %spy_timeline.class.action%
+                component:        %spy_timeline.class.component%
+                action_component: %spy_timeline.class.action_component%
 
-* Run the easy-extends command:
+Extend the Bundle
+-----------------
+
+At this point, the bundle is usable, but not quite ready yet. You need to
+generate the correct entities for the timeline:
 
 .. code-block:: bash
 
-    php app/console sonata:easy-extends:generate SonataTimelineBundle -d src
+    $ php app/console sonata:easy-extends:generate SonataTimelineBundle -dest=src
 
-* Enable the new bundle:
+If you don't specify the ``--dest`` parameter, the files are generated in ``app/Application/Sonata/...```.
+
+.. note::
+
+    The command will generate domain objects in an ``Application`` namespace.
+    So you can point entities associations to a global and common namespace.
+    This will make entities sharing very easily as your models are accessible
+    through a global namespace. For instance the action will be
+    ``Application\Sonata\TimelineBundle\Entity\Action``.
+
+Enable the extended Bundle
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: php
 
+    <?php
     // app/AppKernel.php
+
     public function registerBundles()
     {
         return array(
             // ...
-            new Application\Sonata\TimelineBundle\ApplicationSonataTimelineBundle() // easy extends integration
+
+            // Application Bundles
+            new Application\Sonata\TimelineBundle\ApplicationSonataTimelineBundle(),
+
             // ...
         );
     }
 
-* update your database schema:
+Update the Database Schema
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
 
-    app/console doctrine:schema:update --force
-    
+    $ app/console doctrine:schema:update --force
 
-* enable the block in the admin bundle:
+Enable the Timeline Block
+-------------------------
 
-.. code-block:: yaml
+.. configuration-block::
 
-    sonata_block:
-        # ... other configuration options
+    .. code-block:: yaml
 
-        blocks:
-            # ... other blocks
+        # app/config/config.yml
 
-            sonata.timeline.block.timeline:
-
-    sonata_admin:
-        # ... other configuration options
-
-        dashboard:
+        sonata_block:
             blocks:
-                # ... other blocks
+                # ...
+                sonata.timeline.block.timeline:
 
-                - { position: center, type: sonata.timeline.block.timeline, settings: { context: SONATA_ADMIN, max_per_page: 25 }}
+    .. code-block:: yaml
 
-                # custom title - default: "Latest Actions"
-                - { position: center, type: sonata.timeline.block.timeline, settings: { context: SONATA_ADMIN, max_per_page: 25, title: "My Timeline Block" }}
+        # app/config/config.yml
+
+        sonata_admin:
+            dashboard:
+                blocks:
+                    # ...
+                    - { position: center, type: sonata.timeline.block.timeline, settings: { context: SONATA_ADMIN, max_per_page: 25 }}
+
+And now, you're good to go !
+
+.. _SpyTimelineBundle: https://github.com/stephpy/timeline-bundle


### PR DESCRIPTION
Refs sonata-project/SonataAdminBundle#3310

What did I do?

1. removed to include the ```sonata_timeline.yml``` config file, because in the whole documentation we use the ```app/config/config.yml``` file
2. better structure with subheadlines
3. rewrote the easy extend bundle step like in the page bundle
4. typos

please review this PR!

Thank you :smile: 