### PR TITLE
Remove deprecation warning for admin classes

### DIFF
--- a/Admin/AdminExtension.php
+++ b/Admin/AdminExtension.php
@@ -11,13 +11,13 @@
 
 namespace Sonata\TimelineBundle\Admin;
 
-use Sonata\AdminBundle\Admin\AdminExtension as BaseAdminExtension;
+use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Spy\Timeline\Driver\ActionManagerInterface;
 use Spy\Timeline\Model\ComponentInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
-class AdminExtension extends BaseAdminExtension
+class AdminExtension extends AbstractAdminExtension
 {
     /**
      * @var ActionManagerInterface

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
     },
     "require-dev": {
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "sonata-project/admin-bundle": "^3.0"
+        "sonata-project/admin-bundle": "^3.1"
     },
     "conflict": {
-        "sonata-project/admin-bundle": "<3.0 || >=4.0"
+        "sonata-project/admin-bundle": "<3.1 || >=4.0"
     },
     "autoload": {
         "psr-4": { "Sonata\\TimelineBundle\\": "" },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Removed deprecation warning for `AdminExtension` usage.
```

## Subject

Uses the new `AbstractAdminExtension` class.

