### PR TITLE
Removed deprecations

### DIFF
--- a/Admin/AdminExtension.php
+++ b/Admin/AdminExtension.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Spy\Timeline\Driver\ActionManagerInterface;
 use Spy\Timeline\Model\ComponentInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 class AdminExtension extends AbstractAdminExtension
@@ -25,18 +26,24 @@ class AdminExtension extends AbstractAdminExtension
     protected $actionManager;
 
     /**
-     * @var SecurityContextInterface
+     * @var TokenStorageInterface|SecurityContextInterface
      */
     protected $securityContext;
 
     /**
-     * @param ActionManagerInterface   $actionManager
-     * @param SecurityContextInterface $securityContext
+     * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
+     *
+     * @param ActionManagerInterface                         $actionManager
+     * @param TokenStorageInterface|SecurityContextInterface $tokenStorage
      */
-    public function __construct(ActionManagerInterface $actionManager, SecurityContextInterface $securityContext)
+    public function __construct(ActionManagerInterface $actionManager, $tokenStorage)
     {
+        if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
+            throw new \InvalidArgumentException('Argument 2 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        }
+
         $this->actionManager = $actionManager;
-        $this->securityContext = $securityContext;
+        $this->securityContext = $tokenStorage;
     }
 
     /**

--- a/Block/TimelineBlock.php
+++ b/Block/TimelineBlock.php
@@ -21,6 +21,7 @@ use Spy\Timeline\Model\TimelineInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
@@ -39,22 +40,28 @@ class TimelineBlock extends AbstractAdminBlockService
     protected $timelineManager;
 
     /**
-     * @var SecurityContextInterface
+     * @var TokenStorageInterface|SecurityContextInterface
      */
     protected $securityContext;
 
     /**
-     * @param string                   $name
-     * @param EngineInterface          $templating
-     * @param ActionManagerInterface   $actionManager
-     * @param TimelineManagerInterface $timelineManager
-     * @param SecurityContextInterface $securityContext
+     * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
+     *
+     * @param string                                         $name
+     * @param EngineInterface                                $templating
+     * @param ActionManagerInterface                         $actionManager
+     * @param TimelineManagerInterface                       $timelineManager
+     * @param TokenStorageInterface|SecurityContextInterface $tokenStorage
      */
-    public function __construct($name, EngineInterface $templating, ActionManagerInterface $actionManager, TimelineManagerInterface $timelineManager, SecurityContextInterface $securityContext)
+    public function __construct($name, EngineInterface $templating, ActionManagerInterface $actionManager, TimelineManagerInterface $timelineManager, $tokenStorage)
     {
+        if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
+            throw new \InvalidArgumentException('Argument 5 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        }
+
         $this->actionManager = $actionManager;
         $this->timelineManager = $timelineManager;
-        $this->securityContext = $securityContext;
+        $this->securityContext = $tokenStorage;
 
         parent::__construct($name, $templating);
     }

--- a/Block/TimelineBlock.php
+++ b/Block/TimelineBlock.php
@@ -12,8 +12,8 @@
 namespace Sonata\TimelineBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Spy\Timeline\Driver\ActionManagerInterface;
 use Spy\Timeline\Driver\TimelineManagerInterface;
@@ -26,7 +26,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class TimelineBlock extends BaseBlockService
+class TimelineBlock extends AbstractAdminBlockService
 {
     /**
      * @var ActionManagerInterface

--- a/DependencyInjection/SonataTimelineExtension.php
+++ b/DependencyInjection/SonataTimelineExtension.php
@@ -16,6 +16,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -45,6 +46,24 @@ class SonataTimelineExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('timeline.xml');
+
+        // Set the SecurityContext for Symfony <2.6
+        // NEXT_MAJOR: Go back to simple xml configuration when bumping requirements to SF 2.6+
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            $tokenStorageReference = new Reference('security.token_storage');
+        } else {
+            $tokenStorageReference = new Reference('security.context');
+        }
+
+        $container
+            ->getDefinition('sonata.timeline.admin.extension')
+            ->replaceArgument(1, $tokenStorageReference)
+        ;
+
+        $container
+            ->getDefinition('sonata.timeline.block.timeline')
+            ->replaceArgument(5, $tokenStorageReference)
+        ;
 
         $this->configureClass($config, $container);
         $this->registerDoctrineMapping($config);

--- a/Resources/config/timeline.xml
+++ b/Resources/config/timeline.xml
@@ -4,7 +4,7 @@
         <service id="sonata.timeline.admin.extension" class="Sonata\TimelineBundle\Admin\AdminExtension">
             <tag name="sonata.admin.extension" global="true"/>
             <argument type="service" id="spy_timeline.action_manager"/>
-            <argument type="service" id="security.context"/>
+            <argument/>
         </service>
         <service id="sonata.timeline.spread.admin" class="Sonata\TimelineBundle\Spread\AdminSpread">
             <tag name="spy_timeline.spread"/>
@@ -17,7 +17,7 @@
             <argument type="service" id="templating"/>
             <argument type="service" id="spy_timeline.action_manager"/>
             <argument type="service" id="spy_timeline.timeline_manager"/>
-            <argument type="service" id="security.context"/>
+            <argument/>
         </service>
         <service id="sonata.timeline.twig.extension" class="Sonata\TimelineBundle\Twig\Extension\SonataTimelineExtension">
             <tag name="twig.extension"/>

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/orm": "^2.2",
         "stephpy/timeline-bundle": "^2.3",
         "sonata-project/core-bundle": "^3.0",
-        "sonata-project/block-bundle": "^3.0",
+        "sonata-project/block-bundle": "^3.2",
         "sonata-project/intl-bundle": "^2.2",
         "sonata-project/easy-extends-bundle": "^2.1"
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTimelineBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
 - Removed deprecation for security.context
 - Removed block service deprecation
```

## Subject

Removed symfony and internal deprecation.
