### PR TITLE
added captions to TOC tree in docs

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -17,10 +17,9 @@ for a user or a group of users. The current implementation integrate the basic f
     This is a work in progress, change may occurs in order to tweak performance issues, configuration options, or the
     rendering workflow.
 
-Reference Guide
----------------
-
 .. toctree::
+   :caption: Reference Guide
+   :name: reference-guide
    :maxdepth: 1
    :numbered:
 


### PR DESCRIPTION
I am targeting this branch, because this is a docs change.

## Subject

Added captions to toc tree

This PR is based on the change of @dmarkowicz in https://github.com/sonata-project/SonataAdminBundle/pull/4387
