### PR TITLE
Fixed #112

### DIFF
--- a/DependencyInjection/SonataTimelineExtension.php
+++ b/DependencyInjection/SonataTimelineExtension.php
@@ -62,7 +62,7 @@ class SonataTimelineExtension extends Extension
 
         $container
             ->getDefinition('sonata.timeline.block.timeline')
-            ->replaceArgument(5, $tokenStorageReference)
+            ->replaceArgument(4, $tokenStorageReference)
         ;
 
         $this->configureClass($config, $container);

--- a/Tests/DependencyInjection/SonataTimelineExtensionTest.php
+++ b/Tests/DependencyInjection/SonataTimelineExtensionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\TimelineBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\TimelineBundle\DependencyInjection\SonataTimelineExtension;
+
+class SonataTimelineExtensionTest extends AbstractExtensionTestCase
+{
+    public function testLoadDefault()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sonata.timeline.admin.extension', 1);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sonata.timeline.block.timeline', 4);
+    }
+
+    protected function getContainerExtensions()
+    {
+        return array(
+            new SonataTimelineExtension(),
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "sonata-project/easy-extends-bundle": "^2.1"
     },
     "require-dev": {
+        "matthiasnoback/symfony-dependency-injection-test": "^0.7.6 || ^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/admin-bundle": "^3.1"
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTimelineBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a hotfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #112


## Subject

Fixed wrong argument replacement. There is no 5th parameter for `sonata.timeline.block.timeline`