### PR TITLE
Fixed paths related to SonataEasyExtendsBundle

### DIFF
--- a/Resources/config/doctrine/Action.orm.xml.skeleton
+++ b/Resources/config/doctrine/Action.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\TimelineBundle\Entity\Action"
+        name="{{ namespace }}\Entity\Action"
         table="timeline__action"
         repository-class="Doctrine\ORM\EntityRepository">
 

--- a/Resources/config/doctrine/ActionComponent.orm.xml.skeleton
+++ b/Resources/config/doctrine/ActionComponent.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\TimelineBundle\Entity\ActionComponent"
+        name="{{ namespace }}\Entity\ActionComponent"
         table="timeline__action_component"
         repository-class="Doctrine\ORM\EntityRepository">
 

--- a/Resources/config/doctrine/Component.orm.xml.skeleton
+++ b/Resources/config/doctrine/Component.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\TimelineBundle\Entity\Component"
+        name="{{ namespace }}\Entity\Component"
         table="timeline__component"
         repository-class="Doctrine\ORM\EntityRepository">
 

--- a/Resources/config/doctrine/Timeline.orm.xml.skeleton
+++ b/Resources/config/doctrine/Timeline.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\TimelineBundle\Entity\Timeline"
+        name="{{ namespace }}\Entity\Timeline"
         table="timeline__timeline"
         repository-class="Doctrine\ORM\EntityRepository">
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/block-bundle": "^3.2",
         "sonata-project/intl-bundle": "^2.2",
-        "sonata-project/easy-extends-bundle": "^2.1"
+        "sonata-project/easy-extends-bundle": "^2.2"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.6 || ^1.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTimelineBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because my patch is fixing the bug, arisen due to the hardcoded class-path.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed hardcoded paths to classes in `.xml.skeleton` files of config
```

## Subject

<!-- Describe your Pull Request content here -->
Fixed some hardcoded paths, which become invalid after enabling
the '--namespace' option in SonataEasyExtendsBundle's last release
(https://github.com/sonata-project/SonataEasyExtendsBundle/releases/tag/2.2.0)

See also: https://github.com/sonata-project/SonataMediaBundle/pull/1250