### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
-        "symfony/doctrine-bridge": "^2.3 || ^3.0",
+        "php": "^7.1",
+        "symfony/doctrine-bridge": "^2.8 || ^3.1",
         "doctrine/orm": "^2.2",
         "stephpy/timeline-bundle": "^2.3",
         "sonata-project/core-bundle": "^3.0",

--- a/src/Block/TimelineBlock.php
+++ b/src/Block/TimelineBlock.php
@@ -15,10 +15,13 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Spy\Timeline\Driver\ActionManagerInterface;
 use Spy\Timeline\Driver\TimelineManagerInterface;
 use Spy\Timeline\Model\TimelineInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -102,16 +105,16 @@ class TimelineBlock extends AbstractAdminBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['title', 'text', [
+                ['title', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_title',
                 ]],
-                ['icon', 'text', [
+                ['icon', TextType::class, [
                     'required' => false,
                 ]],
-                ['max_per_page', 'integer', [
+                ['max_per_page', IntegerType::class, [
                     'required' => true,
                     'label' => 'form.label_max_per_page',
                 ]],


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Removed usage of old form type aliases

### Removed
- support for old versions of php and Symfony
```
