### PR TITLE
Drop old versions of sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         "sonata-project/easy-extends-bundle": "^2.2",
         "sonata-project/intl-bundle": "^2.2",
         "stephpy/timeline-bundle": "^2.3",
-        "symfony/doctrine-bridge": "^2.8 || ^3.1"
+        "symfony/doctrine-bridge": "^2.8 || ^3.2"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^0.7.6 || ^1.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/admin-bundle": "^3.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/doctrine-bridge": "^2.8 || ^3.1",
         "doctrine/orm": "^2.2",
-        "stephpy/timeline-bundle": "^2.3",
-        "sonata-project/core-bundle": "^3.0",
         "sonata-project/block-bundle": "^3.2",
+        "sonata-project/core-bundle": "^3.0",
+        "sonata-project/easy-extends-bundle": "^2.2",
         "sonata-project/intl-bundle": "^2.2",
-        "sonata-project/easy-extends-bundle": "^2.2"
+        "stephpy/timeline-bundle": "^2.3",
+        "symfony/doctrine-bridge": "^2.8 || ^3.1"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.6 || ^1.0",
@@ -38,7 +38,10 @@
     },
     "autoload-dev": {
         "psr-4": { "Sonata\\TimelineBundle\\Tests\\": "tests/" }
-     },
+    },
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "3.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "sonata-project/admin-bundle": "^3.1"
+        "sonata-project/admin-bundle": "^3.1",
+        "symfony/phpunit-bridge": "^3.3"
     },
     "conflict": {
         "sonata-project/admin-bundle": "<3.1 || >=4.0"


### PR DESCRIPTION
I am targeting this branch, because this is BC.

There is a separate commit for sort composer packages, because it is applied to all bundles, except this (for the moment is the only I saw without it)

## Changelog

No need for new changelog since it was already on a previous unreleased PR