### PR TITLE
Drop PHPUnit 4

### DIFF
--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -11,13 +11,14 @@
 
 namespace Sonata\TimelineBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\TimelineBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
 
 /**
  * Class ConfigurationTest.
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     public function testBCCode()
     {

--- a/tests/Spread/AdminSpreadTest.php
+++ b/tests/Spread/AdminSpreadTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\TimelineBundle\Tests\Spread;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\TimelineBundle\Spread\AdminSpread;
 use Spy\Timeline\Model\Action;
 use Spy\Timeline\Spread\Entry\EntryCollection;
@@ -51,7 +52,7 @@ class FakeUserEntity
  *
  * @author Vincent Composieux <vincent.composieux@gmail.com>
  */
-class AdminSpreadTest extends \PHPUnit_Framework_TestCase
+class AdminSpreadTest extends TestCase
 {
     /**
      * AdminSpread supported verbs.
@@ -69,7 +70,7 @@ class AdminSpreadTest extends \PHPUnit_Framework_TestCase
      */
     public function testSupportsMethod()
     {
-        $registryMock = $this->getMock('\Symfony\Bridge\Doctrine\RegistryInterface');
+        $registryMock = $this->createMock('\Symfony\Bridge\Doctrine\RegistryInterface');
         $spread = new AdminSpread($registryMock, '\Sonata\TimelineBundle\Tests\Spread\FakeUserEntity');
 
         // Test non-supported verbs

--- a/tests/Twig/Extension/SonataTimelineExtensionTest.php
+++ b/tests/Twig/Extension/SonataTimelineExtensionTest.php
@@ -11,13 +11,14 @@
 
 namespace Sonata\TimelineBundle\Tests\Twig\Extension;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\TimelineBundle\Twig\Extension\SonataTimelineExtension;
 use Spy\TimelineBundle\Document\Action;
 use Spy\TimelineBundle\Document\Component;
 
-class SonataTimelineExtensionTest extends \PHPUnit_Framework_TestCase
+class SonataTimelineExtensionTest extends TestCase
 {
     /**
      * @var SonataTimelineExtension
@@ -36,7 +37,7 @@ class SonataTimelineExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $this->admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
 
         $this->pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')->disableOriginalConstructor()->getMock();
         $this->pool->expects($this->any())


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
Removed compatibility with PHPUnit 4. Fixes: https://github.com/sebastianbergmann/phpunit/issues/2809