### PR TITLE
Restore PHP 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "doctrine/orm": "^2.2",
         "sonata-project/block-bundle": "^3.2",
         "sonata-project/core-bundle": "^3.0",


### PR DESCRIPTION
After the back and forth of PHP versions, we lost 7.1 on master, which was not intended. This PR restores it.