### PR TITLE
Decouple from Templating Component, Stage 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "doctrine/orm": "^2.2",
-        "sonata-project/block-bundle": "^3.2",
+        "sonata-project/block-bundle": "^3.11",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/easy-extends-bundle": "^2.2",
         "sonata-project/intl-bundle": "^2.2",

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -171,7 +171,7 @@ And then edit the sonata_admin definition here, adding the "template" option.
             dashboard:
                 blocks:
                     # ...
-                    - { position: center, type: sonata.timeline.block.timeline, settings: { template: 'ApplicationTimelineBundle::Block:timeline.html.twig', context: SONATA_ADMIN, max_per_page: 25 }}
+                    - { position: center, type: sonata.timeline.block.timeline, settings: { template: '@ApplicationTimeline/Block/timeline.html.twig', context: SONATA_ADMIN, max_per_page: 25 }}
 
 And now, you're good to go !
 

--- a/src/Block/TimelineBlock.php
+++ b/src/Block/TimelineBlock.php
@@ -140,7 +140,7 @@ class TimelineBlock extends AbstractAdminBlockService
             'max_per_page' => 10,
             'title' => 'Latest Actions',
             'icon' => '<i class="fa fa-clock-o fa-fw"></i>',
-            'template' => 'SonataTimelineBundle:Block:timeline.html.twig',
+            'template' => '@SonataTimeline/Block/timeline.html.twig',
             'context' => 'GLOBAL',
             'filter' => true,
             'group_by_action' => true,

--- a/src/Resources/config/timeline.xml
+++ b/src/Resources/config/timeline.xml
@@ -14,7 +14,7 @@
         <service id="sonata.timeline.block.timeline" class="Sonata\TimelineBundle\Block\TimelineBlock">
             <tag name="sonata.block"/>
             <argument>sonata.timeline.block.timeline</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="spy_timeline.action_manager"/>
             <argument type="service" id="spy_timeline.timeline_manager"/>
             <argument/>


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Switch all templates references to Twig namespaced syntax
- Switch from templating service to sonata.templating
```

## To do

- [X] Switch all templates references to Twig namespaced syntax. Update docs, src and tests
- [x] Add `sonata-project/block-bundle` to composer.json
- [x] Switch from `templating` service to `sonata.templating`

## Subject

This PR is a part of a big plan of decoupling sonata-project bundles from Templating Component. See sonata-project/dev-kit#380 for details