### PR TITLE
Added more options to blocks

### DIFF
--- a/src/Block/TimelineBlock.php
+++ b/src/Block/TimelineBlock.php
@@ -108,10 +108,19 @@ class TimelineBlock extends AbstractAdminBlockService
         $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['title', TextType::class, [
-                    'required' => false,
                     'label' => 'form.label_title',
+                    'required' => false,
+                ]],
+                ['translation_domain', TextType::class, [
+                    'label' => 'form.label_translation_domain',
+                    'required' => false,
                 ]],
                 ['icon', TextType::class, [
+                    'label' => 'form.label_icon',
+                    'required' => false,
+                ]],
+                ['class', TextType::class, [
+                    'label' => 'form.label_class',
                     'required' => false,
                 ]],
                 ['max_per_page', IntegerType::class, [
@@ -138,8 +147,10 @@ class TimelineBlock extends AbstractAdminBlockService
     {
         $resolver->setDefaults([
             'max_per_page' => 10,
-            'title' => 'Latest Actions',
-            'icon' => '<i class="fa fa-clock-o fa-fw"></i>',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => 'fa fa-clock-o fa-fw',
+            'class' => null,
             'template' => '@SonataTimeline/Block/timeline.html.twig',
             'context' => 'GLOBAL',
             'filter' => true,

--- a/src/Resources/translations/SonataTimelineBundle.de.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.de.xliff
@@ -46,6 +46,18 @@
                 <source>form.label_max_per_page</source>
                 <target>Einträge pro Seite</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Übersetzungsdatei</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icon</target>
+            </trans-unit>
+            <trans-unit id="form.label_class">
+                <source>form.label_class</source>
+                <target>CSS Klasse</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataTimelineBundle.en.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.en.xliff
@@ -46,6 +46,18 @@
                 <source>form.label_max_per_page</source>
                 <target>Entries per page</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Translation domain</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icon</target>
+            </trans-unit>
+            <trans-unit id="form.label_class">
+                <source>form.label_class</source>
+                <target>CSS Class</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataTimelineBundle.fr.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.fr.xliff
@@ -46,6 +46,18 @@
                 <source>form.label_max_per_page</source>
                 <target>Par page</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Domaine de traduction</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icône</target>
+            </trans-unit>
+            <trans-unit id="form.label_class">
+                <source>form.label_class</source>
+                <target>Classe CSS</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/views/Block/timeline.html.twig
+++ b/src/Resources/views/Block/timeline.html.twig
@@ -11,10 +11,10 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    <div class="box box-primary">
+    <div class="panel panel-default">
         {% if settings.title is not empty %}
-            <div class="box-header with-border">
-                <h4 class="box-title">
+            <div class="panel-heading">
+                <h4 class="panel-title">
                     {% if settings.icon is not empty %}
                         {{ settings.icon|raw }} {{ settings.title }}
                     {% else %}
@@ -24,7 +24,7 @@ file that was distributed with this source code.
             </div>
         {% endif %}
 
-        <div class="box-body">
+        <div class="panel-body">
 
             {% sonata_template_box 'This is the timeline block.' %}
 

--- a/src/Resources/views/Block/timeline.html.twig
+++ b/src/Resources/views/Block/timeline.html.twig
@@ -11,12 +11,15 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    <div class="panel panel-default">
+    <div class="panel panel-default {{ settings.class }}">
         {% if settings.title is not empty %}
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    {% if settings.icon is not empty %}
-                        {{ settings.icon|raw }} {{ settings.title }}
+                    {% if settings.icon %}
+                        <i class="{{ settings.icon }}" aria-hidden="true"></i>
+                    {% endif %}
+                    {% if settings.translation_domain %}
+                        {{ settings.title|trans({}, settings.translation_domain) }}
                     {% else %}
                         {{ settings.title }}
                     {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature is BC (if you ignore the html changes).

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
 - added block title translation domain option
 - added block class option

### Changed
 - changed block icon configuration to icon class instead of html code
 - replaced box with bootstrap panel layout in TimelineBlock

### Removed
 - Removed default title from blocks
```

