### PR TITLE
TimelineBlock cleanup

### DIFF
--- a/src/Resources/views/Block/timeline.html.twig
+++ b/src/Resources/views/Block/timeline.html.twig
@@ -45,7 +45,7 @@ file that was distributed with this source code.
                         {% set subject_text = sonata_timeline_generate_link(subject, entry) %}
                     {% else %}
                         {% set subject_text = '<abbr title="' ~
-                            'element_reference_deleted'|trans({'%reference%': target.hash}, "SonataTimelineBundle") ~ '">' ~
+                            'element_reference_deleted'|trans({'%reference%': subject.hash}, "SonataTimelineBundle") ~ '">' ~
                             'element_deleted'|trans({}, "SonataTimelineBundle") ~
                             '</abbr>'
                         %}

--- a/src/Resources/views/Block/timeline.html.twig
+++ b/src/Resources/views/Block/timeline.html.twig
@@ -44,15 +44,26 @@ file that was distributed with this source code.
                     {% if subject.data %}
                         {% set subject_text = sonata_timeline_generate_link(subject, entry) %}
                     {% else %}
-                        {% set subject_text = '<abbr title="' ~ 'element_reference_deleted'|trans({'%reference%': target.hash}, "SonataTimelineBundle") ~ '">' ~ 'element_deleted'|trans({}, "SonataTimelineBundle") ~ '</abbr>' %}
+                        {% set subject_text = '<abbr title="' ~
+                            'element_reference_deleted'|trans({'%reference%': target.hash}, "SonataTimelineBundle") ~ '">' ~
+                            'element_deleted'|trans({}, "SonataTimelineBundle") ~
+                            '</abbr>'
+                        %}
                     {% endif %}
 
                     {% if target.data is defined and target.data is not empty %}
                         {% set target_text = sonata_timeline_generate_link(target, entry) %}
                     {% elseif target_text_component %}
-                        {% set target_text = '<abbr title="' ~ 'element_deleted'|trans({}, "SonataTimelineBundle") ~ '">'~target_text_component~'</abbr>' %}
+                        {% set target_text = '<abbr title="' ~
+                            'element_deleted'|trans({}, "SonataTimelineBundle") ~
+                            '">'~target_text_component~'</abbr>'
+                        %}
                     {% else %}
-                        {% set target_text = '<abbr title="' ~ 'element_reference_deleted'|trans({'%reference%': target.hash}, "SonataTimelineBundle") ~ '">' ~ 'element_deleted'|trans({}, "SonataTimelineBundle") ~ '</abbr>' %}
+                        {% set target_text = '<abbr title="' ~
+                            'element_reference_deleted'|trans({'%reference%': target.hash}, "SonataTimelineBundle") ~ '">' ~
+                            'element_deleted'|trans({}, "SonataTimelineBundle") ~
+                            '</abbr>'
+                        %}
                     {% endif %}
 
                     {% set verb = "actions."~entry.verb %}

--- a/src/Resources/views/Block/timeline.html.twig
+++ b/src/Resources/views/Block/timeline.html.twig
@@ -28,55 +28,51 @@ file that was distributed with this source code.
         {% endif %}
 
         <div class="panel-body">
+            <ul class="timeline">
+                {% for entry in entries %}
+                    {% if currentDay is not defined or currentDay != entry.createdAt|format_date %}
+                        {% set currentDay = entry.createdAt|format_date %}
+                        <li class="time-label">
+                            <span class="bg-red">{{ currentDay }}</span>
+                        </li>
+                    {% endif %}
 
-            {% sonata_template_box 'This is the timeline block.' %}
+                    {% set subject = entry.getComponent('subject') %}
+                    {% set target = entry.getComponent('target') %}
+                    {% set target_text_component = entry.getComponent('target_text') %}
 
-            <div class="row">
-                <div class="col-md-12">
-                    <ul class="timeline">
-                        {% for entry in entries %}
+                    {% if subject.data %}
+                        {% set subject_text = sonata_timeline_generate_link(subject, entry) %}
+                    {% else %}
+                        {% set subject_text = '<abbr title="' ~ 'element_reference_deleted'|trans({'%reference%': target.hash}, "SonataTimelineBundle") ~ '">' ~ 'element_deleted'|trans({}, "SonataTimelineBundle") ~ '</abbr>' %}
+                    {% endif %}
 
-                            {% if currentDay is not defined or currentDay != entry.createdAt|format_date %}
-                                {% set currentDay = entry.createdAt|format_date %}
-                                <li class="time-label">
-                                    <span class="bg-red">{{ currentDay }}</span>
-                                </li>
-                            {% endif %}
+                    {% if target.data is defined and target.data is not empty %}
+                        {% set target_text = sonata_timeline_generate_link(target, entry) %}
+                    {% elseif target_text_component %}
+                        {% set target_text = '<abbr title="' ~ 'element_deleted'|trans({}, "SonataTimelineBundle") ~ '">'~target_text_component~'</abbr>' %}
+                    {% else %}
+                        {% set target_text = '<abbr title="' ~ 'element_reference_deleted'|trans({'%reference%': target.hash}, "SonataTimelineBundle") ~ '">' ~ 'element_deleted'|trans({}, "SonataTimelineBundle") ~ '</abbr>' %}
+                    {% endif %}
 
-                            {% set subject = entry.getComponent('subject') %}
-                            {% set target = entry.getComponent('target') %}
-                            {% set target_text_component = entry.getComponent('target_text') %}
+                    {% set verb = "actions."~entry.verb %}
+                    {% set icon = "actions.icon."~entry.verb %}
 
-                            {% if subject.data %}
-                                {% set subject_text = sonata_timeline_generate_link(subject, entry) %}
-                            {% else %}
-                                {% set subject_text = '<abbr title="' ~ 'element_reference_deleted'|trans({'%reference%': target.hash}, "SonataTimelineBundle") ~ '">' ~ 'element_deleted'|trans({}, "SonataTimelineBundle") ~ '</abbr>' %}
-                            {% endif %}
-
-                            {% if target.data is defined and target.data is not empty %}
-                                {% set target_text = sonata_timeline_generate_link(target, entry) %}
-                            {% elseif target_text_component %}
-                                {% set target_text = '<abbr title="' ~ 'element_deleted'|trans({}, "SonataTimelineBundle") ~ '">'~target_text_component~'</abbr>' %}
-                            {% else %}
-                                {% set target_text = '<abbr title="' ~ 'element_reference_deleted'|trans({'%reference%': target.hash}, "SonataTimelineBundle") ~ '">' ~ 'element_deleted'|trans({}, "SonataTimelineBundle") ~ '</abbr>' %}
-                            {% endif %}
-
-                            {% set verb = "actions."~entry.verb %}
-                            {% set icon = "actions.icon."~entry.verb %}
-
-                            <li>
-                                <i class="{{ icon|trans({}, "SonataTimelineBundle") }}"></i>
-                                <div class="timeline-item" style="background: #f3f4f5;">
-                                    <span class="time"><i class="fa fa-clock-o"></i> {{ entry.createdAt|format_time }}</span>
-                                    <div class="timeline-body" style="border-bottom: none;">{{ verb|trans({'%subject%': subject_text, '%target%': target_text}, "SonataTimelineBundle")|raw }}</div>
-                                </div>
-                            </li>
-                        {% else %}
-                            {{ 'no_action'|trans({}, "SonataTimelineBundle") }}
-                        {% endfor %}
-                    </ul>
-                </div>
-            </div>
+                    <li>
+                        <i class="{{ icon|trans({}, "SonataTimelineBundle") }}"></i>
+                        <div class="timeline-item" style="background: #f3f4f5;">
+                            <span class="time">
+                                <i class="fa fa-clock-o"></i> {{ entry.createdAt|format_time }}
+                            </span>
+                            <div class="timeline-body" style="border-bottom: none;">
+                                {{ verb|trans({'%subject%': subject_text, '%target%': target_text}, "SonataTimelineBundle")|raw }}
+                            </div>
+                        </div>
+                    </li>
+                {% else %}
+                    <p>{{ 'no_action'|trans({}, "SonataTimelineBundle") }}</p>
+                {% endfor %}
+            </ul>
         </div>
     </div>
 {% endblock %}

--- a/src/Resources/views/Block/timeline.html.twig
+++ b/src/Resources/views/Block/timeline.html.twig
@@ -44,26 +44,27 @@ file that was distributed with this source code.
                     {% if subject.data %}
                         {% set subject_text = sonata_timeline_generate_link(subject, entry) %}
                     {% else %}
-                        {% set subject_text = '<abbr title="' ~
-                            'element_reference_deleted'|trans({'%reference%': subject.hash}, "SonataTimelineBundle") ~ '">' ~
-                            'element_deleted'|trans({}, "SonataTimelineBundle") ~
-                            '</abbr>'
-                        %}
+                        {% set target_text %}
+                            <abbr title="{{ 'element_reference_deleted'|trans({'%reference%': subject.hash}, "SonataTimelineBundle") }}">
+                                {{ 'element_deleted'|trans({}, "SonataTimelineBundle") }}
+                            </abbr>
+                        {% endset %}
                     {% endif %}
 
                     {% if target.data is defined and target.data is not empty %}
                         {% set target_text = sonata_timeline_generate_link(target, entry) %}
                     {% elseif target_text_component %}
-                        {% set target_text = '<abbr title="' ~
-                            'element_deleted'|trans({}, "SonataTimelineBundle") ~
-                            '">'~target_text_component~'</abbr>'
-                        %}
+                        {% set target_text %}
+                            <abbr title="{{ 'element_deleted'|trans({}, "SonataTimelineBundle") }}">
+                                {{ target_text_component }}
+                            </abbr>
+                        {% endset %}
                     {% else %}
-                        {% set target_text = '<abbr title="' ~
-                            'element_reference_deleted'|trans({'%reference%': target.hash}, "SonataTimelineBundle") ~ '">' ~
-                            'element_deleted'|trans({}, "SonataTimelineBundle") ~
-                            '</abbr>'
-                        %}
+                        {% set target_text %}
+                            <abbr title="{{ 'element_reference_deleted'|trans({'%reference%': target.hash}, "SonataTimelineBundle") }}">
+                                {{ 'element_deleted'|trans({}, "SonataTimelineBundle") }}
+                            </abbr>
+                        {% endset %}
                     {% endif %}
 
                     {% set verb = "actions."~entry.verb %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTimelineBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
 - remove some unused divs from `timeline.html.twig` block
```

## Subject

This is a follow-up of #161
