### PR TITLE
Cleanup translations

### DIFF
--- a/src/Resources/translations/SonataTimelineBundle.bg.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.bg.xliff
@@ -26,26 +26,6 @@
                 <source>actions.icon.sonata.admin.delete</source>
                 <target>fa fa-minus-circle bg-red</target>
             </trans-unit>
-            <trans-unit id="7">
-                <source>no_action</source>
-                <target>no_action</target>
-            </trans-unit>
-            <trans-unit id="8">
-                <source>element_deleted</source>
-                <target>element_deleted</target>
-            </trans-unit>
-            <trans-unit id="9">
-                <source>element_reference_deleted</source>
-                <target>element_reference_deleted</target>
-            </trans-unit>
-            <trans-unit id="10">
-                <source>form.label_title</source>
-                <target>form.label_title</target>
-            </trans-unit>
-            <trans-unit id="11">
-                <source>form.label_max_per_page</source>
-                <target>form.label_max_per_page</target>
-            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataTimelineBundle.cs.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.cs.xliff
@@ -26,26 +26,6 @@
                 <source>actions.icon.sonata.admin.delete</source>
                 <target>fa fa-minus-circle bg-red</target>
             </trans-unit>
-            <trans-unit id="7">
-                <source>no_action</source>
-                <target>no_action</target>
-            </trans-unit>
-            <trans-unit id="8">
-                <source>element_deleted</source>
-                <target>element_deleted</target>
-            </trans-unit>
-            <trans-unit id="9">
-                <source>element_reference_deleted</source>
-                <target>element_reference_deleted</target>
-            </trans-unit>
-            <trans-unit id="10">
-                <source>form.label_title</source>
-                <target>form.label_title</target>
-            </trans-unit>
-            <trans-unit id="11">
-                <source>form.label_max_per_page</source>
-                <target>form.label_max_per_page</target>
-            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataTimelineBundle.de.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.de.xliff
@@ -28,7 +28,7 @@
             </trans-unit>
             <trans-unit id="7">
                 <source>no_action</source>
-                <target>Noch keine Aktion ...</target>
+                <target>Noch keine Aktion.</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>element_deleted</source>

--- a/src/Resources/translations/SonataTimelineBundle.en.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.en.xliff
@@ -28,7 +28,7 @@
             </trans-unit>
             <trans-unit id="7">
                 <source>no_action</source>
-                <target>No action for now ...</target>
+                <target>No action for now.</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>element_deleted</source>

--- a/src/Resources/translations/SonataTimelineBundle.es.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.es.xliff
@@ -26,26 +26,6 @@
                 <source>actions.icon.sonata.admin.delete</source>
                 <target>fa fa-minus-circle bg-red</target>
             </trans-unit>
-            <trans-unit id="7">
-                <source>no_action</source>
-                <target>no_action</target>
-            </trans-unit>
-            <trans-unit id="8">
-                <source>element_deleted</source>
-                <target>element_deleted</target>
-            </trans-unit>
-            <trans-unit id="9">
-                <source>element_reference_deleted</source>
-                <target>element_reference_deleted</target>
-            </trans-unit>
-            <trans-unit id="10">
-                <source>form.label_title</source>
-                <target>form.label_title</target>
-            </trans-unit>
-            <trans-unit id="11">
-                <source>form.label_max_per_page</source>
-                <target>form.label_max_per_page</target>
-            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataTimelineBundle.fr.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.fr.xliff
@@ -28,7 +28,7 @@
             </trans-unit>
             <trans-unit id="7">
                 <source>no_action</source>
-                <target>Aucune action actuellement...</target>
+                <target>Aucune action actuellement.</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>element_deleted</source>

--- a/src/Resources/translations/SonataTimelineBundle.nl.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.nl.xliff
@@ -26,26 +26,6 @@
                 <source>actions.icon.sonata.admin.delete</source>
                 <target>fa fa-minus-circle bg-red</target>
             </trans-unit>
-            <trans-unit id="7">
-                <source>no_action</source>
-                <target>no_action</target>
-            </trans-unit>
-            <trans-unit id="8">
-                <source>element_deleted</source>
-                <target>element_deleted</target>
-            </trans-unit>
-            <trans-unit id="9">
-                <source>element_reference_deleted</source>
-                <target>element_reference_deleted</target>
-            </trans-unit>
-            <trans-unit id="10">
-                <source>form.label_title</source>
-                <target>form.label_title</target>
-            </trans-unit>
-            <trans-unit id="11">
-                <source>form.label_max_per_page</source>
-                <target>form.label_max_per_page</target>
-            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataTimelineBundle.pt_BR.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.pt_BR.xliff
@@ -26,26 +26,6 @@
                 <source>actions.icon.sonata.admin.delete</source>
                 <target>fa fa-minus-circle bg-red</target>
             </trans-unit>
-            <trans-unit id="7">
-                <source>no_action</source>
-                <target>no_action</target>
-            </trans-unit>
-            <trans-unit id="8">
-                <source>element_deleted</source>
-                <target>element_deleted</target>
-            </trans-unit>
-            <trans-unit id="9">
-                <source>element_reference_deleted</source>
-                <target>element_reference_deleted</target>
-            </trans-unit>
-            <trans-unit id="10">
-                <source>form.label_title</source>
-                <target>form.label_title</target>
-            </trans-unit>
-            <trans-unit id="11">
-                <source>form.label_max_per_page</source>
-                <target>form.label_max_per_page</target>
-            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataTimelineBundle.ru.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.ru.xliff
@@ -28,7 +28,7 @@
             </trans-unit>
             <trans-unit id="7">
                 <source>no_action</source>
-                <target>Сейчас нет никаких действий ...</target>
+                <target>Сейчас нет никаких действий.</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>element_deleted</source>

--- a/src/Resources/translations/SonataTimelineBundle.sk.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.sk.xliff
@@ -26,26 +26,6 @@
                 <source>actions.icon.sonata.admin.delete</source>
                 <target>fa fa-minus-circle bg-red</target>
             </trans-unit>
-            <trans-unit id="7">
-                <source>no_action</source>
-                <target>no_action</target>
-            </trans-unit>
-            <trans-unit id="8">
-                <source>element_deleted</source>
-                <target>element_deleted</target>
-            </trans-unit>
-            <trans-unit id="9">
-                <source>element_reference_deleted</source>
-                <target>element_reference_deleted</target>
-            </trans-unit>
-            <trans-unit id="10">
-                <source>form.label_title</source>
-                <target>form.label_title</target>
-            </trans-unit>
-            <trans-unit id="11">
-                <source>form.label_max_per_page</source>
-                <target>form.label_max_per_page</target>
-            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataTimelineBundle.sl.xliff
+++ b/src/Resources/translations/SonataTimelineBundle.sl.xliff
@@ -26,26 +26,6 @@
                 <source>actions.icon.sonata.admin.delete</source>
                 <target>fa fa-minus-circle bg-red</target>
             </trans-unit>
-            <trans-unit id="7">
-                <source>no_action</source>
-                <target>no_action</target>
-            </trans-unit>
-            <trans-unit id="8">
-                <source>element_deleted</source>
-                <target>element_deleted</target>
-            </trans-unit>
-            <trans-unit id="9">
-                <source>element_reference_deleted</source>
-                <target>element_reference_deleted</target>
-            </trans-unit>
-            <trans-unit id="10">
-                <source>form.label_title</source>
-                <target>form.label_title</target>
-            </trans-unit>
-            <trans-unit id="11">
-                <source>form.label_max_per_page</source>
-                <target>form.label_max_per_page</target>
-            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTimelineBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because translation files are pedantic.

## Subject

Removed wrong default translations, so you will now get a warning if your translation is missing and the fallback is used.

Replaced `...` after `No action for now` with one dot. This looks more professional ;)