### PR TITLE
Added support for timeline-bundle 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/easy-extends-bundle": "^2.2",
         "sonata-project/intl-bundle": "^2.2",
-        "stephpy/timeline-bundle": "^2.3",
+        "stephpy/timeline-bundle": "^2.3 || ^3.0",
         "symfony/doctrine-bridge": "^2.8 || ^3.2 || ^4.0"
     },
     "conflict": {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTimelineBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for `timeline-bundle` 3.0
```

## Subject

This is needed if you want to use `doctrine/orm` 2.6 (https://github.com/stephpy/timeline-bundle/pull/210)