### PR TITLE
Fix the subject_text when data is empty.

### DIFF
--- a/src/Resources/views/Block/timeline.html.twig
+++ b/src/Resources/views/Block/timeline.html.twig
@@ -44,7 +44,7 @@ file that was distributed with this source code.
                     {% if subject.data %}
                         {% set subject_text = sonata_timeline_generate_link(subject, entry) %}
                     {% else %}
-                        {% set target_text %}
+                        {% set subject_text %}
                             <abbr title="{{ 'element_reference_deleted'|trans({'%reference%': subject.hash}, "SonataTimelineBundle") }}">
                                 {{ 'element_deleted'|trans({}, "SonataTimelineBundle") }}
                             </abbr>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTimelineBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #169 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix the subject_text when data is empty.
```

<!--
## To do

    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note
-->

## Subject

<!-- Describe your Pull Request content here -->
After deleting a subject, the timeline on the dashboard cannot be displayed. Because the target text was set instead of the subject text.
