### PR TITLE
Twig deprecation notice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
         "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
         "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0",
-        "symfony/security-core": "^2.8 || ^3.2 || ^4.0"
+        "symfony/security-core": "^2.8 || ^3.2 || ^4.0",
+        "twig/twig": "^1.35 || ^2.4"
     },
     "conflict": {
         "sonata-project/admin-bundle": "<3.31 || >=4.0",

--- a/src/Twig/Extension/SonataTimelineExtension.php
+++ b/src/Twig/Extension/SonataTimelineExtension.php
@@ -17,8 +17,10 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Spy\Timeline\Model\ActionInterface;
 use Spy\Timeline\Model\ComponentInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class SonataTimelineExtension extends \Twig_Extension
+class SonataTimelineExtension extends AbstractExtension
 {
     /**
      * @var Pool
@@ -39,7 +41,7 @@ class SonataTimelineExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sonata_timeline_generate_link', [$this, 'generateLink'], ['is_safe' => ['html']]),
+            new TwigFunction('sonata_timeline_generate_link', [$this, 'generateLink'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/tests/Spread/AdminSpreadTest.php
+++ b/tests/Spread/AdminSpreadTest.php
@@ -102,7 +102,7 @@ class AdminSpreadTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods(['getUsers'])
             ->getMock();
-        $spread->expects($this->any())->method('getUsers')->will($this->returnValue($this->getFakeUsers()));
+        $spread->expects($this->any())->method('getUsers')->willReturn($this->getFakeUsers());
 
         $collection = new EntryCollection();
         $spread->process($action, $collection);

--- a/tests/Twig/Extension/SonataTimelineExtensionTest.php
+++ b/tests/Twig/Extension/SonataTimelineExtensionTest.php
@@ -45,7 +45,7 @@ class SonataTimelineExtensionTest extends TestCase
         $this->pool->expects($this->any())
             ->method('getAdminByClass')
             ->with($this->equalTo('Acme\DemoBundle\Model\Demo'))
-            ->will($this->returnValue($this->admin));
+            ->willReturn($this->admin);
 
         $this->twigExtension = new SonataTimelineExtension($this->pool);
     }
@@ -61,21 +61,21 @@ class SonataTimelineExtensionTest extends TestCase
         $this->admin->expects($this->once())
             ->method('hasRoute')
             ->with($this->equalTo('edit'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->admin->expects($this->once())
             ->method('isGranted')
             ->with($this->equalTo('EDIT'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->admin->expects($this->once())
             ->method('generateObjectUrl')
             ->with($this->equalTo('edit'), $this->anything())
-            ->will($this->returnValue('acme/demo/2/edit'));
+            ->willReturn('acme/demo/2/edit');
 
         $this->admin->expects($this->once())
             ->method('toString')
             ->with($this->anything())
-            ->will($this->returnValue('Text'));
+            ->willReturn('Text');
 
         $this->assertSame('<a href="acme/demo/2/edit">Text</a>', $this->twigExtension->generateLink($component, $action));
     }
@@ -91,25 +91,25 @@ class SonataTimelineExtensionTest extends TestCase
         $this->admin->expects($this->at(0))
             ->method('hasRoute')
             ->with($this->equalTo('edit'))
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $this->admin->expects($this->at(1))
             ->method('hasRoute')
             ->with($this->equalTo('show'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->admin->expects($this->at(2))
             ->method('isGranted')
             ->with($this->equalTo('SHOW'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->admin->expects($this->once())
             ->method('generateObjectUrl')
             ->with($this->equalTo('show'), $this->anything())
-            ->will($this->returnValue('acme/demo/2/show'));
+            ->willReturn('acme/demo/2/show');
 
         $this->admin->expects($this->once())
             ->method('toString')
             ->with($this->anything())
-            ->will($this->returnValue('Text'));
+            ->willReturn('Text');
 
         $this->assertSame('<a href="acme/demo/2/show">Text</a>', $this->twigExtension->generateLink($component, $action));
     }
@@ -125,29 +125,29 @@ class SonataTimelineExtensionTest extends TestCase
         $this->admin->expects($this->at(0))
             ->method('hasRoute')
             ->with($this->equalTo('edit'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->admin->expects($this->at(1))
             ->method('isGranted')
             ->with($this->equalTo('EDIT'))
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $this->admin->expects($this->at(2))
             ->method('hasRoute')
             ->with($this->equalTo('show'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->admin->expects($this->at(3))
             ->method('isGranted')
             ->with($this->equalTo('SHOW'))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->admin->expects($this->once())
             ->method('generateObjectUrl')
             ->with($this->equalTo('show'), $this->anything())
-            ->will($this->returnValue('acme/demo/2/show'));
+            ->willReturn('acme/demo/2/show');
 
         $this->admin->expects($this->once())
             ->method('toString')
             ->with($this->anything())
-            ->will($this->returnValue('Text'));
+            ->willReturn('Text');
 
         $this->assertSame('<a href="acme/demo/2/show">Text</a>', $this->twigExtension->generateLink($component, $action));
     }
@@ -163,16 +163,16 @@ class SonataTimelineExtensionTest extends TestCase
         $this->admin->expects($this->at(0))
             ->method('hasRoute')
             ->with($this->equalTo('edit'))
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $this->admin->expects($this->at(1))
             ->method('hasRoute')
             ->with($this->equalTo('show'))
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->admin->expects($this->once())
             ->method('toString')
             ->with($this->anything())
-            ->will($this->returnValue('Text'));
+            ->willReturn('Text');
 
         $this->assertSame('Text', $this->twigExtension->generateLink($component, $action));
     }


### PR DESCRIPTION
## Subject
Fixing Twig deprecation notice in Symfony 4

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add missing package `twig/twig` with versions `^1.35 || ^2.4`

### Fixed
* deprecation notice about using namespaced classes from `\Twig\`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
