### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     },
     "conflict": {
         "sonata-project/admin-bundle": "<3.56.1 || >=4.0",
+        "sonata-project/core-bundle": "<3.20",
         "sonata-project/user-bundle": "<4.3"
     },
     "require-dev": {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This change will allow install optionally only CoreBundle v3.20 (which constains all deprecations notes).

#### Remove process will be look like:
- update CoreBundle to 3.20
- remove deprecations
- remove CoreBundle
- upgrade extensions to 1.x

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCommentBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targeting this branch, because this change respect BC.

