### PR TITLE
Make SonataEasyExtends optional

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,11 +1,19 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+========================
+
+### SonataEasyExtends is deprecated
+
+Registering `SonataEasyExtendsBundle` bundle is deprecated, it SHOULD NOT be registered.
+Register `SonataDoctrineBundle` bundle instead.
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. 
-You can't extend them anymore, because they are only loaded when running internal tests. 
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "doctrine/orm": "^2.2",
         "doctrine/persistence": "^1.3",
         "sonata-project/block-bundle": "^3.17",
-        "sonata-project/easy-extends-bundle": "^2.5",
+        "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "stephpy/timeline-bundle": "^2.3 || ^3.0",
         "symfony/config": "^4.4",
@@ -47,6 +47,7 @@
         "sonata-project/user-bundle": "<4.3"
     },
     "require-dev": {
+        "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "sonata-project/admin-bundle": "^3.56.1",
         "sonata-project/user-bundle": "^4.3",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -58,6 +58,7 @@ class Configuration implements ConfigurationInterface
                             return $v;
                         })
                     ->end()
+                    ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('component')->defaultValue('%spy_timeline.class.component%')->cannotBeEmpty()->end()
                         // NEXT_MAJOR: Remove this key

--- a/src/DependencyInjection/SonataTimelineExtension.php
+++ b/src/DependencyInjection/SonataTimelineExtension.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\TimelineBundle\DependencyInjection;
 
-use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
+use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
+use Sonata\Doctrine\Mapper\DoctrineCollector;
+use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector as DeprecatedDoctrineCollector;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -38,6 +40,7 @@ class SonataTimelineExtension extends Extension
         $processor = new Processor();
         $configuration = new Configuration();
         $config = $processor->processConfiguration($configuration, $configs);
+        $bundles = $container->getParameter('kernel.bundles');
 
         $config = $this->addDefaults($config);
 
@@ -50,7 +53,13 @@ class SonataTimelineExtension extends Extension
         $loader->load(sprintf('timeline_%s.xml', $config['manager_type']));
 
         $this->configureClass($config, $container);
-        $this->registerDoctrineMapping($config);
+
+        if (isset($bundles['SonataDoctrineBundle'])) {
+            $this->registerSonataDoctrineMapping($config);
+        } else {
+            // NEXT MAJOR: Remove next line and throw error when not registering SonataDoctrineBundle
+            $this->registerDoctrineMapping($config);
+        }
     }
 
     /**
@@ -90,15 +99,23 @@ class SonataTimelineExtension extends Extension
         $container->setParameter(sprintf('sonata.timeline.admin.user.%s', $modelType), $config['class']['user']);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function registerDoctrineMapping(array $config)
     {
+        @trigger_error(
+            'Using SonataEasyExtendsBundle is deprecated since sonata-project/timeline-bundle 3.x. Please register SonataDoctrineBundle as a bundle instead.',
+            E_USER_DEPRECATED
+        );
+
         foreach ($config['class'] as $type => $class) {
             if (!class_exists($class)) {
                 return;
             }
         }
 
-        $collector = DoctrineCollector::getInstance();
+        $collector = DeprecatedDoctrineCollector::getInstance();
 
         $collector->addAssociation($config['class']['timeline'], 'mapManyToOne', [
             'fieldName' => 'action',
@@ -177,5 +194,74 @@ class SonataTimelineExtension extends Extension
             ],
             'orphanRemoval' => false,
         ]);
+    }
+
+    private function registerSonataDoctrineMapping(array $config): void
+    {
+        foreach ($config['class'] as $type => $class) {
+            if (!class_exists($class)) {
+                return;
+            }
+        }
+
+        $collector = DoctrineCollector::getInstance();
+
+        $componentOptions = OptionsBuilder::createManyToOne('component', $config['class']['component'])
+            ->addJoin([
+                'name' => 'component_id',
+                'referencedColumnName' => 'id',
+                'onDelete' => 'CASCADE',
+            ]);
+
+        $collector->addAssociation(
+            $config['class']['timeline'],
+            'mapManyToOne',
+            OptionsBuilder::createManyToOne('action', $config['class']['action'])
+                ->inversedBy('timelines')
+                ->addJoin([
+                    'name' => 'action_id',
+                    'referencedColumnName' => 'id',
+                ])
+        );
+
+        $collector->addAssociation(
+            $config['class']['timeline'],
+            'mapManyToOne',
+            OptionsBuilder::createManyToOne('subject', $config['class']['component'])
+                ->addJoin([
+                    'name' => 'subject_id',
+                    'referencedColumnName' => 'id',
+                    'onDelete' => 'CASCADE',
+                ])
+        );
+
+        $collector->addAssociation(
+            $config['class']['action'],
+            'mapOneToMany',
+            OptionsBuilder::createOneToMany('actionComponents', $config['class']['action_component'])
+                ->cascade(['persist'])
+                ->mappedBy('action')
+        );
+
+        $collector->addAssociation(
+            $config['class']['action'],
+            'mapOneToMany',
+            OptionsBuilder::createOneToMany('timelines', $config['class']['timeline'])
+                ->mappedBy('action')
+        );
+
+        $collector->addAssociation(
+            $config['class']['action_component'],
+            'mapManyToOne',
+            OptionsBuilder::createManyToOne('action', $config['class']['action'])
+                ->inversedBy('actionComponents')
+                ->addJoin([
+                    'name' => 'action_id',
+                    'referencedColumnName' => 'id',
+                    'onDelete' => 'CASCADE',
+                ])
+        );
+
+        $collector->addAssociation($config['class']['action_component'], 'mapManyToOne', $componentOptions);
     }
 }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -13,30 +13,37 @@ declare(strict_types=1);
 
 namespace Sonata\TimelineBundle\Tests\DependencyInjection;
 
-use PHPUnit\Framework\TestCase;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
 use Sonata\TimelineBundle\DependencyInjection\Configuration;
-use Symfony\Component\Config\Definition\Processor;
+use Sonata\TimelineBundle\DependencyInjection\SonataTimelineExtension;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
-class ConfigurationTest extends TestCase
+final class ConfigurationTest extends AbstractExtensionConfigurationTestCase
 {
-    public function testBCCode(): void
+    public function testDefault(): void
     {
-        $processor = new Processor();
-        $configuration = $processor->processConfiguration(new Configuration(), [[
-            'class' => ['actionComponent' => 'stdClass'],
-        ]]);
-
-        $expected = [
+        $this->assertProcessedConfigurationEquals([
+            'manager_type' => 'orm',
             'class' => [
-                'action_component' => 'stdClass',
                 'component' => '%spy_timeline.class.component%',
+                'action_component' => '%spy_timeline.class.action_component%',
                 'action' => '%spy_timeline.class.action%',
                 'timeline' => '%spy_timeline.class.timeline%',
                 'user' => '%sonata.user.admin.user.entity%',
             ],
-            'manager_type' => 'orm',
-        ];
+        ], [
+            __DIR__.'/../Fixtures/configuration.yaml',
+        ]);
+    }
 
-        $this->assertSame($expected, $configuration);
+    protected function getContainerExtension(): ExtensionInterface
+    {
+        return new SonataTimelineExtension();
+    }
+
+    protected function getConfiguration(): ConfigurationInterface
+    {
+        return new Configuration();
     }
 }

--- a/tests/DependencyInjection/SonataTimelineExtensionTest.php
+++ b/tests/DependencyInjection/SonataTimelineExtensionTest.php
@@ -18,6 +18,12 @@ use Sonata\TimelineBundle\DependencyInjection\SonataTimelineExtension;
 
 class SonataTimelineExtensionTest extends AbstractExtensionTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container->setParameter('kernel.bundles', ['SonataDoctrineBundle' => true]);
+    }
+
     public function testLoadDefault(): void
     {
         $this->load(['class' => [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

Part of: https://github.com/sonata-project/dev-kit/issues/750

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

SonataEasyExtends is deprecated but it is used on many bundles, this makes it optional. This change is BC because if the user does not change anything it will continue using the deprecated code but with a message.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataArticleBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- SonataEasyExtendsBundle is now optional, using SonataDoctrineBundle is preferred
### Deprecated
- Using SonataEasyExtendsBundle to add Doctrine mapping information
```

## To do

- [x] Update the documentation;
- [x] Add an upgrade note.
